### PR TITLE
Added some new configuration options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ minutes-format | <sup>2</sub> | Minutes format in `hour` view.
 minutes-step | `5` | Step between each visible minute in `hour` view.
 seconds-format | `"ss"` | Seconds format in `minute` view.
 seconds-step | `1` | Step between each visible second in `minute` view.
+dayViewHoursStart | `0` | The first hour displayed in `day` view.
+dayViewHoursEnd | `23` | The last hour displayed in `day` view.
+showHeaderView | `true` | Show the header in the view.
 
 ## Notes
 

--- a/src/angular-moment-picker.js
+++ b/src/angular-moment-picker.js
@@ -8,23 +8,26 @@
 		
 		function momentPickerProvider() {
 			defaults = {
-				locale:        'en',
-				format:        'L LTS',
-				minView:       'decade',
-				maxView:       'minute',
-				startView:     'year',
-				autoclose:     true,
-				today:         false,
-				keyboard:      false,
-				leftArrow:     '&larr;',
-				rightArrow:    '&rarr;',
-				yearsFormat:   'YYYY',
-				monthsFormat:  'MMM',
-				daysFormat:    'D',
-				hoursFormat:   'HH:[00]',
-				secondsFormat: 'ss',
-				minutesStep:   5,
-				secondsStep:   1
+				locale:                 'en',
+				format:                 'L LTS',
+				minView:                'decade',
+				maxView:                'minute',
+				startView:              'year',
+				autoclose:              true,
+				today:                  false,
+				keyboard:               false,
+				leftArrow:              '&larr;',
+				rightArrow:             '&rarr;',
+				yearsFormat:            'YYYY',
+				monthsFormat:           'MMM',
+				daysFormat:             'D',
+				hoursFormat:            'HH:[00]',
+				secondsFormat:          'ss',
+				minutesStep:            5,
+				secondsStep:            1,
+				dayViewHoursStart:      0,
+				dayViewHoursEnd:        23,
+				showHeaderView:         true
 			};
 		}
 		momentPickerProvider.prototype.options = function (options) {
@@ -90,7 +93,7 @@
 			$scope.template = (
 				'<div class="moment-picker-container {{view.selected}}-view" ' +
 					'ng-show="view.isOpen && !disabled" ng-class="{\'moment-picker-disabled\': disabled, \'open\': view.isOpen}">' +
-					'<table class="header-view">' +
+					'<table class="header-view" ng-hide="!showHeaderView">' +
 						'<thead>' +
 							'<tr>' +
 								'<th ng-class="{disabled: !view.previous.selectable}" ng-bind-html="view.previous.label" ng-click="view.previous.set()"></th>' +
@@ -155,7 +158,7 @@
 			);
 			
 			// one-way binding attributes
-			angular.forEach(['locale', 'format', 'minView', 'maxView', 'startView', 'autoclose', 'today', 'keyboard', 'leftArrow', 'rightArrow'], function (attr) {
+			angular.forEach(['locale', 'format', 'minView', 'maxView', 'startView', 'autoclose', 'today', 'keyboard', 'leftArrow', 'rightArrow', 'showHeaderView'], function (attr) {
 				if (!angular.isDefined($scope[attr])) $scope[attr] = momentPicker[attr];
 				if (!angular.isDefined($attrs[attr])) $attrs[attr] = $scope[attr];
 			});
@@ -456,12 +459,13 @@
 			$scope.dayView = {
 				perLine: 4,
 				threeHours: [],
+				threeHoursIndex: 0,
 				render: function () {
-					var hour = $scope.view.moment.clone().startOf('day');
-					
+					var hour = $scope.view.moment.clone().startOf('day').add(momentPicker.dayViewHoursStart, 'hours');
+					$scope.dayView.threeHoursIndex = 0;
 					$scope.dayView.threeHours = [];
-					for (var h = 0; h < 24; h++) {
-						var index = Math.floor(h / $scope.dayView.perLine),
+					for (var h = momentPicker.dayViewHoursStart; h <= momentPicker.dayViewHoursEnd; h++) {
+						var index = $scope.dayView.threeHoursIndex,
 							selectable = $scope.limits.isSelectable(hour, 'hour');
 						
 						if (!$scope.dayView.threeHours[index])
@@ -479,7 +483,11 @@
 							selectable: selectable
 						});
 						hour.add(1, 'hours');
+
+						if ($scope.dayView.threeHours[index].length === $scope.dayView.perLine)
+							$scope.dayView.threeHoursIndex++;
 					}
+
 					// return title
 					return $scope.view.moment.format('LL');
 				},


### PR DESCRIPTION
I have created a branch with some new configuration options which were useful for a project I was working on. The current `master` branch always displays the day view by showing the hours 00:00 -> 23:00. If the control is being used as strictly a time picker then sometimes it would be nice to restrict this to a set of working hours (e.g. 08:00 -> 17:00). To facilitate that, I have added some new options:

- `dayViewHoursStart` - The hour to start the day view at. e.g. `8` will show 08:00 as the first hour in the day view popup. (default `0`)
- `dayViewHoursEnd` - The hour to end the day view at. e.g. `17` will show 17:00 as the last hour in the day view popup. (default `23`)
- `showHeaderView` - Whether or not to show the date/navigation header in the popup. This can be hidden via CSS anyway but it is good to be able to configure it. (default `true`)