### PR TITLE
Prevents a bug where $scope.valueMoment is undefined

### DIFF
--- a/src/angular-moment-picker.js
+++ b/src/angular-moment-picker.js
@@ -653,8 +653,16 @@
 				$scope.limits.checkValue();
 			});
 			$scope.$watch('value', function () {
+
 				var oldValue = $scope.model,
-					newValue = $scope.valueMoment && $scope.valueMoment.format($scope.format);
+					newValue;
+
+                if (!$scope.valueMoment) {
+                    return;
+                }
+
+                newValue = $scope.valueMoment.format($scope.format);
+
 				if (newValue != oldValue)
 					$timeout(function () {
 						$scope.view.update($scope.view.moment = $scope.valueMoment.clone());


### PR DESCRIPTION
This change prevents the `clone` function being called on
$scope.valueMoment when $scope.valueMoment is undefined.

Observed in some code where ng-if is used to expose a region of controls
in which a moment-pocker directive is placed.