### PR TITLE
Add use strict

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+'use strict';
+
 let pkg = require('./package');
 let bower = require('./bower');
 let semver = require('semver');


### PR DESCRIPTION
I'm getting the following error when building on v5.12.0 of node:
```bash
npm run build
```
```bash
SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outsid
e strict mode                                                                                
    at exports.runInThisContext (vm.js:53:16)                                                
    at Module._compile (module.js:387:25)                                                    
    at Object.Module._extensions..js (module.js:422:10)                                      
    at Module.load (module.js:357:32)                                                        
    at Function.Module._load (module.js:314:12)                                              
    at Module.require (module.js:367:17)                                                     
    at require (internal/module.js:20:19)                                                    
    at module.exports (C:\GitHub\angular-moment-picker\node_modules\web
pack\bin\convert-argv.js:80:13)                                                              
    at Object.<anonymous> (C:\GitHub\angular-moment-picker\node_modules
\webpack\bin\webpack.js:39:40)                                                               
    at Module._compile (module.js:413:34)                                                    
```
Adding `use strict`  resolves the problem.