### PR TITLE
Do not disable keyboard input if keyboard option is set to true

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -359,7 +359,6 @@ export default class Directive implements ng.IDirective {
 				.on('blur', () => $scope.$evalAsync($scope.view.close))
 				.on('keydown', (e: JQueryEventObject) => {
 					if (!$scope.keyboard) return;
-					e.preventDefault();
 					$scope.$evalAsync(() => $scope.view.keydown(e));
 				});
 			$scope.contents.on('mousedown', () => focusInput());


### PR DESCRIPTION
The keydown function already does a preventDefault() on keys like UP, DOWN, RETURN, ... . There is no need to completely disable all keys on the input (like TAB to jump to the next input).