### PR TITLE
Update directive.ts

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -401,7 +401,7 @@ export default class Directive implements ng.IDirective {
 				$scope.view.render();
 			});
 			$scope.$watch(() => toValue($scope.startDate, $scope.format, $scope.locale), (newViewValue, oldViewValue) => {
-				if (newViewValue == oldViewValue) return;
+				if (!newViewValue || (newViewValue == oldViewValue)) return;
 
 				$scope.view.moment = valueToMoment(newViewValue, $scope);
 				$scope.view.update();


### PR DESCRIPTION
Solving a bug : selection of a date is not possible anymore after this process with an input field date : 
- select a date 
- remove the date by deleting with keyboard
- go outside the field (focus lost) => here we can see errors in logs (js error "cannot clone() on undefined value")
- return to the field trying to select a date with mouse => KO = not possible
(... But user is not blocked, he can always type a new date and then selection with mouse works again...)