### PR TITLE
Fixed `.moment-picker table` view - set equal width for table cells.

### DIFF
--- a/src/index.less
+++ b/src/index.less
@@ -72,7 +72,13 @@
     }
 
     // all views
-    table { border-collapse: collapse; border-spacing: 0; min-width: 100%; table-layout: fixed; }
+    table {
+        border-collapse: collapse;
+        border-spacing: 0;
+        width: 100%;
+        table-layout: fixed;
+    }
+
     th {
         font-weight: bold;
         &:first-child, &:last-child { width: 2em; }


### PR DESCRIPTION
For correct work of `table-layout: fixed;` property, `.moment-picker table` must have a width property.
I'm replace `min-width: 100%` to `width: 100%`.