### PR TITLE
Fix Angular-moment-picker IN UI-GRD

### DIFF
--- a/src/directive.ts
+++ b/src/directive.ts
@@ -168,6 +168,9 @@ export default class Directive implements ng.IDirective {
 					$scope.view.isOpen = false;
 					$scope.view.selected = $scope.startView;
 					$scope.picker[0].parentNode.removeChild($scope.picker[0]);
+					//$scope.$emit(uiGridEditConstants.events.END_CELL_EDIT);  <-- the right way
+					$scope.$emit('uiGridEventEndCellEdit');
+					
 				},
 				position: () => {
 					if (!$scope.view.isOpen || $scope.position || $scope.inline) return;


### PR DESCRIPTION
When angular-moment-picker is used in ui-grid and a date is picked the cell doesn't become uneditable back to its initial state.
Generate event for end cell edit when picker si closed. Must be further tested